### PR TITLE
why not follow standard restful API convention?

### DIFF
--- a/api/getting-started.md
+++ b/api/getting-started.md
@@ -13,7 +13,6 @@ Base API URL is [https://digital-quran.quranacademy.org](https://digital-quran.q
 ## General concepts
 
 * API works exclusively over HTTPS.
-* Every API request must be performed using POST method.
 * Every API request must be a valid JSON and include "Content-Type: application/json" header.
 * Every API request must include "Language" header with the code of a language. See the [list of available languages](https://github.com/quranacademy/digital-quran-docs/tree/897278b43c9c88853ed2c939278b8d7f042acb77/api/available-languages.md).
 * Every request to the API must be authenticated.


### PR DESCRIPTION
* Every API request must be performed using POST method.
It would be more convenient to use other HTTP methods (GET, PUT, PATCH, DELETE) as required. There is a convention to use them as you can read at [wikipedia](https://en.wikipedia.org/wiki/Representational_state_transfer#Applied%20to%20Web%20services#Relationship_between_URI_and_HTTP_methods) and other sites like [restfulapi.net](https://restfulapi.net/http-methods/)