### PR TITLE
why response should have a redundant "data" key?

### DIFF
--- a/api/public-endpoints/languages.md
+++ b/api/public-endpoints/languages.md
@@ -15,27 +15,25 @@ None.
 ### Response
 
 ```javascript
-{
-    "data": [
-        {
-          "code": "ar",
-          "name": "Arabic",
-          "native_name": "العربية",
-          "direction": "rtl"
-        },
-        {
-          "code": "en",
-          "name": "English",
-          "native_name": "English",
-          "direction": "ltr"
-        },
-        {
-          "code": "ru",
-          "name": "Russian",
-          "native_name": "Русский",
-          "direction": "ltr"
-        }
-    ]
-}
+[
+      {
+        "code": "ar",
+        "name": "Arabic",
+        "native_name": "العربية",
+        "direction": "rtl"
+      },
+      {
+        "code": "en",
+        "name": "English",
+        "native_name": "English",
+        "direction": "ltr"
+      },
+      {
+        "code": "ru",
+        "name": "Russian",
+        "native_name": "Русский",
+        "direction": "ltr"
+      }
+]
 ```
 


### PR DESCRIPTION
Extra "data" key in response in unnecessary and redundant. it would put unnecessary extra work on the client side.